### PR TITLE
fix: correct instancePath for required errors inside array items

### DIFF
--- a/lib/js-compiler.js
+++ b/lib/js-compiler.js
@@ -2331,13 +2331,16 @@ function genCodeC(schema, v, pathExpr, lines, ctx, schemaPrefix) {
     if (destructKeys.length > 0) lines.push(`const{${destructKeys.join(',')}}=${v}`)
     for (const key of schema.required) {
       const check = hoisted[key] ? `${hoisted[key]}===undefined` : `${v}[${JSON.stringify(key)}]===undefined`
-      // Pre-allocate required errors as frozen closure variables
-      const ei = ctx.varCounter++
-      const errVar = `_E${ei}`
-      const pathVal = pathExpr ? pathExpr.slice(1, -1) : ''
-      ctx.closureVars.push(errVar)
-      ctx.closureVals.push(Object.freeze({keyword: 'required', instancePath: pathVal, schemaPath: `${schemaPrefix}/required`, params: Object.freeze({missingProperty: key}), message: `must have required property '${key}'`}))
-      lines.push(`if(${check}){(_e||(_e=[])).push(${errVar})}`)
+      if (isStaticPath) {
+        const ei = ctx.varCounter++
+        const errVar = `_E${ei}`
+        const pathVal = pathExpr ? pathExpr.slice(1, -1) : ''
+        ctx.closureVars.push(errVar)
+        ctx.closureVals.push(Object.freeze({keyword: 'required', instancePath: pathVal, schemaPath: `${schemaPrefix}/required`, params: Object.freeze({missingProperty: key}), message: `must have required property '${key}'`}))
+        lines.push(`if(${check}){(_e||(_e=[])).push(${errVar})}`)
+      } else {
+        lines.push(`if(${check}){(_e||(_e=[])).push({keyword:'required',instancePath:${pathExpr||'""'},schemaPath:'${schemaPrefix}/required',params:{missingProperty:'${esc(key)}'},message:"must have required property '${esc(key)}'"})}`)
+      }
     }
   } else if (schema.required) {
     for (const key of schema.required) {

--- a/tests/test_ajv_errors.js
+++ b/tests/test_ajv_errors.js
@@ -253,7 +253,72 @@ console.log('\n--- nested path ---')
   )
 }
 
-// --- 21. dependentRequired ---
+// --- 21. array item required (instancePath must use index, not codegen expression) ---
+console.log('\n--- array item required ---')
+{
+  const schema = {
+    type: 'object',
+    properties: {
+      like: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name']
+        }
+      }
+    }
+  }
+  const v = new Validator(schema, { allErrors: true })
+  const result = v.validate({ like: [{}] })
+  const errors = result.errors || []
+  const e = errors.find(err => err.keyword === 'required' && err.params && err.params.missingProperty === 'name')
+  assert(!result.valid, 'array item required: validation fails')
+  assert(e !== null && e !== undefined, 'array item required: error found')
+  assert(
+    e && e.instancePath === '/like/0',
+    `array item required: instancePath is "/like/0" (got ${e && e.instancePath})`
+  )
+  assert(
+    e && e.schemaPath === '#/properties/like/items/required',
+    `array item required: schemaPath correct (got ${e && e.schemaPath})`
+  )
+  assert(
+    e && e.message === "must have required property 'name'",
+    `array item required: message correct (got ${e && e.message})`
+  )
+}
+
+{
+  const schema = {
+    type: 'object',
+    properties: {
+      like: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name']
+        }
+      }
+    }
+  }
+  const v = new Validator(schema, { allErrors: true })
+  const result = v.validate({ like: [{}, { name: 'ok' }, {}] })
+  const errors = result.errors || []
+  const reqErrors = errors.filter(err => err.keyword === 'required' && err.params && err.params.missingProperty === 'name')
+  assert(reqErrors.length === 2, `array item required multi: 2 errors (got ${reqErrors.length})`)
+  assert(
+    reqErrors[0] && reqErrors[0].instancePath === '/like/0',
+    `array item required multi: first error at /like/0 (got ${reqErrors[0] && reqErrors[0].instancePath})`
+  )
+  assert(
+    reqErrors[1] && reqErrors[1].instancePath === '/like/2',
+    `array item required multi: second error at /like/2 (got ${reqErrors[1] && reqErrors[1].instancePath})`
+  )
+}
+
+// --- 22. dependentRequired ---
 console.log('\n--- dependentRequired ---')
 {
   const schema = {


### PR DESCRIPTION
## Problem

When validating objects inside arrays (e.g. `items` of an array schema), the `instancePath` for `required` keyword errors is corrupted. Instead of producing a path like `/like/0`, the generated code produces garbled values like `/like'+'/'+_j`.

### Root Cause

In `genCodeC` (`lib/js-compiler.js`), the required-error pre-allocation block unconditionally calls `pathExpr.slice(1, -1)` to extract the path value. This works correctly when `pathExpr` is a static string literal like `"'/foo"'`, but inside array item loops, `pathExpr` is a **dynamic JS expression** like `"'/like"'+"'/"'+_j0` (built by `childPathDynExpr`). Calling `.slice(1, -1)` on that expression strips characters from the source code string rather than the runtime value, producing invalid paths.

### Fix

Added the same `isStaticPath` guard that the `else if (schema.required)` branch and the `fail()` helper already use:

- **Static paths** (root-level or known-depth objects): Keep frozen pre-allocated closure errors (zero allocation on valid data, no perf change).
- **Dynamic paths** (array items, `patternProperties`, etc.): Emit inline error objects with the runtime-evaluated `instancePath` expression, which is the only correct approach since array indices are unknown at compile time.

### Verification

```js
const { Validator } = require("./lib/index.js");
const v = new Validator({
  type: "object",
  properties: {
    like: {
      type: "array",
      items: { type: "object", properties: { name: { type: "string" } }, required: ["name"] }
    }
  }
}, { allErrors: true });

const result = v.validate({ like: [{}] });
// Before fix: instancePath = "/like'+'/'+_j4" (broken)
// After fix:  instancePath = "/like/0"            (correct)
```

No performance impact on the valid-data hot path since frozen pre-allocated errors are still used for all static paths.