### PR TITLE
fix: duplicate regex variables created

### DIFF
--- a/lib/js-compiler.js
+++ b/lib/js-compiler.js
@@ -956,6 +956,9 @@ function tryGenCombined(schema, access, ctx) {
 // 'string' / 'number' / 'integer' = we know the primitive type
 function genCode(schema, v, lines, ctx, knownType) {
   if (typeof schema !== 'object' || schema === null) return
+  if (!ctx.regExpMap) {
+    ctx.regExpMap = new Map();
+  }
 
   // $ref — guard against circular references
   // In 2020-12 with unevaluated*, $ref can coexist with siblings — don't early return
@@ -1176,8 +1179,13 @@ function genCode(schema, v, lines, ctx, knownType) {
     if (inlineCheck) {
       lines.push(isStr ? `if(!(${inlineCheck}))return false` : `if(typeof ${v}==='string'&&!(${inlineCheck}))return false`)
     } else {
-      const ri = ctx.varCounter++
-      ctx.helperCode.push(`const _re${ri}=new RegExp(${JSON.stringify(schema.pattern)})`)
+      const pattern = JSON.stringify(schema.pattern);
+      if (!ctx.regExpMap.has(pattern)) {
+        const ri = ctx.varCounter++
+        ctx.regExpMap.set(pattern, ri)
+        ctx.helperCode.push(`const _re${ri}=new RegExp(${pattern})`);
+      }
+      const ri = ctx.regExpMap.get(pattern);
       lines.push(isStr ? `if(!_re${ri}.test(${v}))return false` : `if(typeof ${v}==='string'&&!_re${ri}.test(${v}))return false`)
     }
   }
@@ -2296,7 +2304,9 @@ function compileToJSCodegenWithErrors(schema, schemaMap) {
 function genCodeE(schema, v, pathExpr, lines, ctx, schemaPrefix) {
   if (!schemaPrefix) schemaPrefix = '#'
   if (typeof schema !== 'object' || schema === null) return
-
+  if (!ctx.regExpMap) {
+    ctx.regExpMap = new Map();
+  }
   // $ref — resolve local and cross-schema refs
   if (schema.$ref) {
     // Self-reference "#" — no-op (permissive) to avoid infinite recursion
@@ -2453,8 +2463,13 @@ function genCodeE(schema, v, pathExpr, lines, ctx, schemaPrefix) {
       const c = isStr ? `!(${inlineCheck})` : `typeof ${v}==='string'&&!(${inlineCheck})`
       lines.push(`if(${c}){${fail('pattern', 'pattern', `{pattern:${JSON.stringify(schema.pattern)}}`, `'must match pattern "${schema.pattern}"'`)}}`)
     } else {
-      const ri = ctx.varCounter++
-      ctx.helperCode.push(`const _re${ri}=new RegExp(${JSON.stringify(schema.pattern)})`)
+      const pattern = JSON.stringify(schema.pattern);
+      if (!ctx.regExpMap.has(pattern)) {
+        const ri = ctx.varCounter++
+        ctx.regExpMap.set(pattern, ri)
+        ctx.helperCode.push(`const _re${ri}=new RegExp(${pattern})`)
+      }
+      const ri = ctx.regExpMap.get(pattern);
       const c = isStr ? `!_re${ri}.test(${v})` : `typeof ${v}==='string'&&!_re${ri}.test(${v})`
       lines.push(`if(${c}){${fail('pattern', 'pattern', `{pattern:${JSON.stringify(schema.pattern)}}`, `'must match pattern "${schema.pattern}"'`)}}`)
     }
@@ -2539,8 +2554,13 @@ function genCodeE(schema, v, pathExpr, lines, ctx, schemaPrefix) {
   // patternProperties
   if (schema.patternProperties) {
     for (const [pat, sub] of Object.entries(schema.patternProperties)) {
-      const ri = ctx.varCounter++
-      ctx.helperCode.push(`const _re${ri}=new RegExp(${JSON.stringify(pat)})`)
+      const pattern = JSON.stringify(pat);
+      if (!ctx.regExpMap.has(pattern)) {
+        const ri = ctx.varCounter++
+        ctx.regExpMap.set(pattern, ri)
+        ctx.helperCode.push(`const _re${ri}=new RegExp(${pattern})`);
+      }
+      const ri = ctx.regExpMap.get(pattern);
       const ki = ctx.varCounter++
       lines.push(`if(typeof ${v}==='object'&&${v}!==null&&!Array.isArray(${v})){for(const _k${ki} in ${v}){if(_re${ri}.test(_k${ki})){`)
       const p = pathExpr ? `${pathExpr}+'/'+_k${ki}` : `'/'+_k${ki}`
@@ -2570,8 +2590,13 @@ function genCodeE(schema, v, pathExpr, lines, ctx, schemaPrefix) {
       lines.push(`if(_k${ki}.length>${pn.maxLength}){${fail('maxLength', 'propertyNames/maxLength', `{limit:${pn.maxLength}}`, `'must NOT have more than ${pn.maxLength} characters'`)}}`)
     }
     if (pn.pattern) {
-      const ri = ctx.varCounter++
-      ctx.helperCode.push(`const _re${ri}=new RegExp(${JSON.stringify(pn.pattern)})`)
+      const pattern = JSON.stringify(pn.pattern);
+      if (!ctx.regExpMap.has(pattern)) {
+        const ri = ctx.varCounter++
+        ctx.regExpMap.set(pattern, ri)
+        ctx.helperCode.push(`const _re${ri}=new RegExp(${pattern})`);
+      }
+      const ri = ctx.regExpMap.get(pattern);
       lines.push(`if(!_re${ri}.test(_k${ki})){${fail('pattern', 'propertyNames/pattern', `{pattern:${JSON.stringify(pn.pattern)}}`, `'must match pattern "${pn.pattern}"'`)}}`)
     }
     if (pn.const !== undefined) {


### PR DESCRIPTION
Fix: duplicate variables created while generating `standaloneCode`.

**example**

```json
{
  	"$schema": "http://json-schema.org/draft-07/schema#",
    "properties": {
      "certificationValue": {
        "maxLength": 200,
        "minLength": 1,
        "type": "string"
      },
      "certificateIssuanceDateTime": {
        "pattern": "-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?|(24:00:00(\\.0+)?))(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?",
        "type": "string"
      },
      "certificationEffectiveEndDateTime": {
        "pattern": "-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?|(24:00:00(\\.0+)?))(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?",
        "type": "string"
      },
      "certificationEffectiveStartDateTime": {
        "pattern": "-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?|(24:00:00(\\.0+)?))(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?",
        "type": "string"
      },
    },
    "type": "object"
  }
```

Instead of creating 3 regex variables created. Only one will be created.