### PR TITLE
feat: tier-dispatched interpreter for cold-path validation

### DIFF
--- a/benchmark/after_M1.txt
+++ b/benchmark/after_M1.txt
@@ -1,0 +1,71 @@
+[90mclk: ~4.35 GHz[0m
+[90mcpu: Apple M4 Pro[0m
+[90mruntime: node 25.2.1 (arm64-darwin)[0m
+
+benchmark                   avg (min … max) p75 / p99    (min … top 1%)
+------------------------------------------- -------------------------------
+• S1 warm-cached: construct + 1 validate (same schema object reused)
+[90m------------------------------------------- -------------------------------[0m
+ata (this)                   [1m[33m 26.47 ns[0m[1m/iter[0m [90m 26.87 ns[0m [36m █ [0m[33m [0m[35m                 [0m
+                     [90m([0m[36m23.97 ns[0m[90m … [0m[35m122.12 ns[0m[90m)[0m [90m 41.26 ns[0m [36m █▃[0m[33m [0m[35m                 [0m
+                    [90m([0m[33m 88.97  b[0m[90m … [0m[33m450.24  b[0m[90m) [0m[33m184.58  b[0m [36m▇██[0m[33m▅[0m[35m▅▃▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁[0m
+
+ajv compile + validate       [1m[33m  1.50 ms[0m[1m/iter[0m [90m  1.62 ms[0m [36m ▆█▃[0m[33m [0m[35m                [0m
+                        [90m([0m[36m1.17 ms[0m[90m … [0m[35m2.98 ms[0m[90m)[0m [90m  2.64 ms[0m [36m ███[0m[33m▅[0m[35m▄▃              [0m
+                    [90m([0m[33m  1.13 mb[0m[90m … [0m[33m  8.04 mb[0m[90m) [0m[33m  2.93 mb[0m [36m▆███[0m[33m█[0m[35m██▇▆▅▃▃▂▂▁▂▂▂▁▁▁[0m
+
+ajv precompiled (baseline)   [1m[33m  9.45 ns[0m[1m/iter[0m [90m  9.30 ns[0m [36m    █[0m[33m [0m[35m               [0m
+                      [90m([0m[36m7.24 ns[0m[90m … [0m[35m137.62 ns[0m[90m)[0m [90m 15.99 ns[0m [36m    █[0m[33m [0m[35m               [0m
+                    [90m([0m[33m  8.21  b[0m[90m … [0m[33m141.11  b[0m[90m) [0m[33m 56.06  b[0m [36m▂▂▂▂█[0m[33m▆[0m[35m▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁[0m
+
+[1msummary[0m
+  [1m[36majv precompiled (baseline)[0m
+   [32m2.8[0mx faster than [1m[36mata (this)[0m
+   [32m158656[0mx faster than [1m[36majv compile + validate[0m
+
+• S2 warm-cached: 10 props with enum/format
+[90m------------------------------------------- -------------------------------[0m
+ata (this)                   [1m[33m 97.08 ns[0m[1m/iter[0m [90m 98.59 ns[0m [36m █[0m[33m [0m[35m                  [0m
+                     [90m([0m[36m79.80 ns[0m[90m … [0m[35m602.02 ns[0m[90m)[0m [90m263.42 ns[0m [36m▄█[0m[33m▅[0m[35m                  [0m
+                    [90m([0m[33m 24.90  b[0m[90m … [0m[33m536.16  b[0m[90m) [0m[33m288.41  b[0m [36m██[0m[33m█[0m[35m▆▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁[0m
+
+ajv compile + validate       [1m[33m  1.59 ms[0m[1m/iter[0m [90m  1.67 ms[0m [36m █▇▃[0m[33m [0m[35m                [0m
+                        [90m([0m[36m1.32 ms[0m[90m … [0m[35m6.42 ms[0m[90m)[0m [90m  2.54 ms[0m [36m▃███[0m[33m▇[0m[35m▅▅▅             [0m
+                    [90m([0m[33m  1.69 mb[0m[90m … [0m[33m  4.34 mb[0m[90m) [0m[33m  3.20 mb[0m [36m████[0m[33m█[0m[35m███▅▂▂▃▂▁▂▂▁▁▁▁▁[0m
+
+ajv precompiled (baseline)   [1m[33m 17.59 ns[0m[1m/iter[0m [90m 18.02 ns[0m [36m    [0m[33m█[0m[35m                [0m
+                      [90m([0m[36m15.35 ns[0m[90m … [0m[35m72.33 ns[0m[90m)[0m [90m 25.34 ns[0m [36m▃█▃ [0m[33m█[0m[35m▄               [0m
+                    [90m([0m[33m 24.11  b[0m[90m … [0m[33m172.11  b[0m[90m) [0m[33m 56.11  b[0m [36m███▄[0m[33m█[0m[35m█▅▃▅▅▄▂▂▂▂▁▁▁▁▁▁[0m
+
+[1msummary[0m
+  [1m[36majv precompiled (baseline)[0m
+   [32m5.52[0mx faster than [1m[36mata (this)[0m
+   [32m90560.51[0mx faster than [1m[36majv compile + validate[0m
+
+• S1 TRUE COLD: fresh schema each iteration
+[90m------------------------------------------- -------------------------------[0m
+ata (this) fresh-schema      [1m[33m 82.73 ns[0m[1m/iter[0m [90m 80.75 ns[0m [36m█▅[0m[33m [0m[35m                  [0m
+                       [90m([0m[36m66.22 ns[0m[90m … [0m[35m1.13 µs[0m[90m)[0m [90m233.64 ns[0m [36m██[0m[33m [0m[35m                  [0m
+                    [90m([0m[33m 28.81  b[0m[90m … [0m[33m  1.04 kb[0m[90m) [0m[33m288.57  b[0m [36m██[0m[33m▇[0m[35m▅▄▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁[0m
+
+ajv compile+validate fresh   [1m[33m  1.36 ms[0m[1m/iter[0m [90m  1.44 ms[0m [36m ▄█  [0m[33m [0m[35m               [0m
+                        [90m([0m[36m1.17 ms[0m[90m … [0m[35m2.58 ms[0m[90m)[0m [90m  1.91 ms[0m [36m ███▂[0m[33m [0m[35m▂              [0m
+                    [90m([0m[33m  1.21 mb[0m[90m … [0m[33m  4.41 mb[0m[90m) [0m[33m  2.88 mb[0m [36m▇████[0m[33m█[0m[35m█▅▅▆▅▄▄▃▂▃▃▂▂▂▁[0m
+
+[1msummary[0m
+  [1m[36mata (this) fresh-schema[0m
+   [32m16490.09[0mx faster than [1m[36majv compile+validate fresh[0m
+
+• S2 TRUE COLD: fresh schema each iteration
+[90m------------------------------------------- -------------------------------[0m
+ata (this) fresh-schema      [1m[33m144.00 ns[0m[1m/iter[0m [90m144.70 ns[0m [36m █ [0m[33m [0m[35m                 [0m
+                      [90m([0m[36m124.21 ns[0m[90m … [0m[35m1.55 µs[0m[90m)[0m [90m241.21 ns[0m [36m █▆[0m[33m [0m[35m                 [0m
+                    [90m([0m[33m  7.44  b[0m[90m … [0m[33m  2.68 kb[0m[90m) [0m[33m291.65  b[0m [36m▆██[0m[33m█[0m[35m▆▄▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁[0m
+
+ajv compile+validate fresh   [1m[33m  1.41 ms[0m[1m/iter[0m [90m  1.43 ms[0m [36m █▂ [0m[33m [0m[35m                [0m
+                        [90m([0m[36m1.30 ms[0m[90m … [0m[35m2.51 ms[0m[90m)[0m [90m  1.84 ms[0m [36m ██▃[0m[33m [0m[35m                [0m
+                    [90m([0m[33m  1.70 mb[0m[90m … [0m[33m  4.09 mb[0m[90m) [0m[33m  3.18 mb[0m [36m████[0m[33m▆[0m[35m▆▄▄▃▃▃▂▂▂▂▁▂▂▂▂▁[0m
+
+[1msummary[0m
+  [1m[36mata (this) fresh-schema[0m
+   [32m9765.91[0mx faster than [1m[36majv compile+validate fresh[0m

--- a/benchmark/baseline_before_M1.txt
+++ b/benchmark/baseline_before_M1.txt
@@ -1,0 +1,71 @@
+[90mclk: ~4.38 GHz[0m
+[90mcpu: Apple M4 Pro[0m
+[90mruntime: node 25.2.1 (arm64-darwin)[0m
+
+benchmark                   avg (min … max) p75 / p99    (min … top 1%)
+------------------------------------------- -------------------------------
+• S1 warm-cached: construct + 1 validate (same schema object reused)
+[90m------------------------------------------- -------------------------------[0m
+ata (this)                   [1m[33m649.09 ns[0m[1m/iter[0m [90m500.00 ns[0m [36m  █   [0m[33m [0m[35m              [0m
+                      [90m([0m[36m375.00 ns[0m[90m … [0m[35m5.77 ms[0m[90m)[0m [90m  1.29 µs[0m [36m  ██  [0m[33m [0m[35m              [0m
+                    [90m([0m[33m  1.12 kb[0m[90m … [0m[33m249.34 kb[0m[90m) [0m[33m  1.62 kb[0m [36m▁▂██▅▄[0m[33m▃[0m[35m▂▁▁▁▁▁▁▁▁▁▁▁▁▁[0m
+
+ajv compile + validate       [1m[33m  1.38 ms[0m[1m/iter[0m [90m  1.48 ms[0m [36m ▇█  [0m[33m [0m[35m               [0m
+                        [90m([0m[36m1.16 ms[0m[90m … [0m[35m2.55 ms[0m[90m)[0m [90m  2.08 ms[0m [36m ██▅▄[0m[33m [0m[35m               [0m
+                    [90m([0m[33m949.18 kb[0m[90m … [0m[33m  7.44 mb[0m[90m) [0m[33m  2.92 mb[0m [36m▆████[0m[33m█[0m[35m██▆▇▆▂▃▂▃▂▁▂▁▂▁[0m
+
+ajv precompiled (baseline)   [1m[33m  8.46 ns[0m[1m/iter[0m [90m  8.68 ns[0m [36m █  [0m[33m▂[0m[35m                [0m
+                       [90m([0m[36m7.36 ns[0m[90m … [0m[35m52.88 ns[0m[90m)[0m [90m 12.36 ns[0m [36m █  [0m[33m█[0m[35m                [0m
+                    [90m([0m[33m 15.65  b[0m[90m … [0m[33m104.11  b[0m[90m) [0m[33m 56.05  b[0m [36m██▇▅[0m[33m█[0m[35m█▅▇▃▂▂▂▂▂▁▁▁▁▁▁▁[0m
+
+[1msummary[0m
+  [1m[36majv precompiled (baseline)[0m
+   [32m76.74[0mx faster than [1m[36mata (this)[0m
+   [32m163728.62[0mx faster than [1m[36majv compile + validate[0m
+
+• S2 warm-cached: 10 props with enum/format
+[90m------------------------------------------- -------------------------------[0m
+ata (this)                   [1m[33m933.58 ns[0m[1m/iter[0m [90m792.00 ns[0m [36m   █     [0m[33m [0m[35m           [0m
+                      [90m([0m[36m666.00 ns[0m[90m … [0m[35m3.66 ms[0m[90m)[0m [90m  1.25 µs[0m [36m   █▃    [0m[33m [0m[35m           [0m
+                    [90m([0m[33m  1.53 kb[0m[90m … [0m[33m218.55 kb[0m[90m) [0m[33m  1.55 kb[0m [36m▁▃▁██▁▃▃▁[0m[33m▁[0m[35m▂▂▁▁▂▁▁▁▁▁▁[0m
+
+ajv compile + validate       [1m[33m  1.51 ms[0m[1m/iter[0m [90m  1.57 ms[0m [36m ▂█▂[0m[33m [0m[35m                [0m
+                        [90m([0m[36m1.33 ms[0m[90m … [0m[35m2.44 ms[0m[90m)[0m [90m  2.17 ms[0m [36m ███[0m[33m▃[0m[35m                [0m
+                    [90m([0m[33m  1.41 mb[0m[90m … [0m[33m  4.65 mb[0m[90m) [0m[33m  3.22 mb[0m [36m▃███[0m[33m█[0m[35m▇▆▆▄▄▃▃▁▂▂▁▂▁▁▁▁[0m
+
+ajv precompiled (baseline)   [1m[33m 20.89 ns[0m[1m/iter[0m [90m 21.49 ns[0m [36m ▆█ [0m[33m [0m[35m                [0m
+                      [90m([0m[36m19.35 ns[0m[90m … [0m[35m61.50 ns[0m[90m)[0m [90m 26.33 ns[0m [36m ███[0m[33m▂[0m[35m                [0m
+                    [90m([0m[33m  6.11  b[0m[90m … [0m[33m218.12  b[0m[90m) [0m[33m 56.17  b[0m [36m▄███[0m[33m█[0m[35m▅▄█▇▅▄▂▂▂▂▁▁▁▁▁▁[0m
+
+[1msummary[0m
+  [1m[36majv precompiled (baseline)[0m
+   [32m44.69[0mx faster than [1m[36mata (this)[0m
+   [32m72412.57[0mx faster than [1m[36majv compile + validate[0m
+
+• S1 TRUE COLD: fresh schema each iteration
+[90m------------------------------------------- -------------------------------[0m
+ata (this) fresh-schema      [1m[33m554.36 ns[0m[1m/iter[0m [90m448.62 ns[0m [36m█▂[0m[33m [0m[35m                  [0m
+                      [90m([0m[36m410.53 ns[0m[90m … [0m[35m2.05 µs[0m[90m)[0m [90m  1.69 µs[0m [36m██[0m[33m [0m[35m                  [0m
+                    [90m([0m[33m669.41  b[0m[90m … [0m[33m  1.46 kb[0m[90m) [0m[33m  1.21 kb[0m [36m██[0m[33m▁[0m[35m▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▂▂[0m
+
+ajv compile+validate fresh   [1m[33m  1.27 ms[0m[1m/iter[0m [90m  1.27 ms[0m [36m  ▃█ [0m[33m [0m[35m               [0m
+                        [90m([0m[36m1.15 ms[0m[90m … [0m[35m1.78 ms[0m[90m)[0m [90m  1.61 ms[0m [36m  ███[0m[33m [0m[35m               [0m
+                    [90m([0m[33m  1.31 mb[0m[90m … [0m[33m  3.92 mb[0m[90m) [0m[33m  2.87 mb[0m [36m▂▄███[0m[33m▇[0m[35m▆▃▃▃▂▂▂▃▂▂▂▂▂▁▁[0m
+
+[1msummary[0m
+  [1m[36mata (this) fresh-schema[0m
+   [32m2283.54[0mx faster than [1m[36majv compile+validate fresh[0m
+
+• S2 TRUE COLD: fresh schema each iteration
+[90m------------------------------------------- -------------------------------[0m
+ata (this) fresh-schema      [1m[33m823.05 ns[0m[1m/iter[0m [90m724.67 ns[0m [36m █ [0m[33m [0m[35m                 [0m
+                      [90m([0m[36m674.94 ns[0m[90m … [0m[35m1.74 µs[0m[90m)[0m [90m  1.71 µs[0m [36m █ [0m[33m [0m[35m                 [0m
+                    [90m([0m[33m116.22  b[0m[90m … [0m[33m  1.67 kb[0m[90m) [0m[33m  1.44 kb[0m [36m██▁[0m[33m▁[0m[35m▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂[0m
+
+ajv compile+validate fresh   [1m[33m  1.43 ms[0m[1m/iter[0m [90m  1.43 ms[0m [36m   █ [0m[33m [0m[35m               [0m
+                        [90m([0m[36m1.30 ms[0m[90m … [0m[35m1.90 ms[0m[90m)[0m [90m  1.83 ms[0m [36m  ██▄[0m[33m [0m[35m               [0m
+                    [90m([0m[33m  1.78 mb[0m[90m … [0m[33m  4.08 mb[0m[90m) [0m[33m  3.19 mb[0m [36m▂▇███[0m[33m▇[0m[35m▅▃▂▃▂▂▃▃▃▂▁▂▁▂▁[0m
+
+[1msummary[0m
+  [1m[36mata (this) fresh-schema[0m
+   [32m1735.24[0mx faster than [1m[36majv compile+validate fresh[0m

--- a/benchmark/bench_cold_path.mjs
+++ b/benchmark/bench_cold_path.mjs
@@ -1,0 +1,135 @@
+// Cold-path benchmark: measures `new Validator(schema) + isValidObject(data)` total time.
+// Target (M1): S1 < 1.5μs, S2 < 2μs.
+
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+import { bench, group, run, summary } from "mitata";
+
+const Ajv = require("./node_modules/ajv");
+const { Validator } = require("../index.js");
+
+const schemas = {
+  S1: {
+    type: "object",
+    properties: {
+      id: { type: "integer", minimum: 1 },
+      name: { type: "string", minLength: 1 },
+      active: { type: "boolean" },
+    },
+    required: ["id", "name"],
+  },
+  S2: {
+    type: "object",
+    properties: {
+      id: { type: "integer", minimum: 1 },
+      name: { type: "string", minLength: 1, maxLength: 100 },
+      email: { type: "string" },
+      age: { type: "integer", minimum: 0, maximum: 150 },
+      role: { type: "string", enum: ["admin", "user", "guest"] },
+      active: { type: "boolean" },
+      score: { type: "number", minimum: 0, maximum: 100 },
+      tag: { type: "string", maxLength: 20 },
+      createdAt: { type: "string" },
+      flags: { type: "string" },
+    },
+    required: ["id", "name", "email"],
+  },
+};
+
+const payloads = {
+  S1: { id: 1, name: "alice", active: true },
+  S2: {
+    id: 1,
+    name: "alice",
+    email: "a@b.com",
+    age: 30,
+    role: "user",
+    active: true,
+    score: 95.5,
+    tag: "t1",
+    createdAt: "2026-04-16",
+    flags: "x",
+  },
+};
+
+const _ajvInit = new Ajv();
+const _ajvS1 = _ajvInit.compile(schemas.S1);
+const _ajvS2 = _ajvInit.compile(schemas.S2);
+
+// Pre-generate a pool of fresh schema object instances to defeat identity-cache hits.
+// Each bench call pulls a fresh object from the pool so ata can't reuse a cached validator.
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+const POOL = 5000;
+const freshS1 = Array.from({ length: POOL }, () => clone(schemas.S1));
+const freshS2 = Array.from({ length: POOL }, () => clone(schemas.S2));
+let i1 = 0, i2 = 0;
+
+group("S1 warm-cached: construct + 1 validate (same schema object reused)", () => {
+  summary(() => {
+    bench("ata (this)", () => {
+      const v = new Validator(schemas.S1);
+      return v.isValidObject(payloads.S1);
+    });
+    bench("ajv compile + validate", () => {
+      const ajv = new Ajv();
+      const v = ajv.compile(schemas.S1);
+      return v(payloads.S1);
+    });
+    bench("ajv precompiled (baseline)", () => {
+      return _ajvS1(payloads.S1);
+    });
+  });
+});
+
+group("S2 warm-cached: 10 props with enum/format", () => {
+  summary(() => {
+    bench("ata (this)", () => {
+      const v = new Validator(schemas.S2);
+      return v.isValidObject(payloads.S2);
+    });
+    bench("ajv compile + validate", () => {
+      const ajv = new Ajv();
+      const v = ajv.compile(schemas.S2);
+      return v(payloads.S2);
+    });
+    bench("ajv precompiled (baseline)", () => {
+      return _ajvS2(payloads.S2);
+    });
+  });
+});
+
+group("S1 TRUE COLD: fresh schema each iteration", () => {
+  summary(() => {
+    bench("ata (this) fresh-schema", () => {
+      const s = freshS1[(i1++) % POOL];
+      const v = new Validator(s);
+      return v.isValidObject(payloads.S1);
+    });
+    bench("ajv compile+validate fresh", () => {
+      const s = freshS1[(i1++) % POOL];
+      const ajv = new Ajv();
+      const v = ajv.compile(s);
+      return v(payloads.S1);
+    });
+  });
+});
+
+group("S2 TRUE COLD: fresh schema each iteration", () => {
+  summary(() => {
+    bench("ata (this) fresh-schema", () => {
+      const s = freshS2[(i2++) % POOL];
+      const v = new Validator(s);
+      return v.isValidObject(payloads.S2);
+    });
+    bench("ajv compile+validate fresh", () => {
+      const s = freshS2[(i2++) % POOL];
+      const ajv = new Ajv();
+      const v = ajv.compile(s);
+      return v(payloads.S2);
+    });
+  });
+});
+
+await run();

--- a/benchmark/bench_first_call.mjs
+++ b/benchmark/bench_first_call.mjs
@@ -1,0 +1,97 @@
+// First-call cold start benchmark: measures the TRUE one-shot cost where nothing
+// is cached yet. Relevant to serverless cold starts, CLI tools, config parsing.
+// Each iteration runs in a fresh Node.js process to avoid any JIT/cache carryover.
+//
+// Run: node bench_first_call.mjs
+// Output: median/p95/p99 over N fresh-process runs.
+
+import { spawnSync } from "child_process";
+import { writeFileSync, unlinkSync } from "fs";
+
+const schemas = {
+  S1: {
+    type: "object",
+    properties: {
+      id: { type: "integer", minimum: 1 },
+      name: { type: "string", minLength: 1 },
+      active: { type: "boolean" },
+    },
+    required: ["id", "name"],
+  },
+  S2: {
+    type: "object",
+    properties: {
+      id: { type: "integer", minimum: 1 },
+      name: { type: "string", minLength: 1, maxLength: 100 },
+      email: { type: "string" },
+      age: { type: "integer", minimum: 0, maximum: 150 },
+      role: { type: "string", enum: ["admin", "user", "guest"] },
+      active: { type: "boolean" },
+      score: { type: "number", minimum: 0, maximum: 100 },
+      tag: { type: "string", maxLength: 20 },
+      createdAt: { type: "string" },
+      flags: { type: "string" },
+    },
+    required: ["id", "name", "email"],
+  },
+};
+const payloads = {
+  S1: { id: 1, name: "alice", active: true },
+  S2: { id: 1, name: "alice", email: "a@b.com", age: 30, role: "user", active: true, score: 95.5, tag: "t1", createdAt: "2026-04-16", flags: "x" },
+};
+
+function runChild(scriptPath) {
+  const r = spawnSync(process.execPath, [scriptPath], { encoding: "utf8" });
+  const out = r.stdout.trim();
+  const ns = parseInt(out, 10);
+  return ns;
+}
+
+function measure(label, script, runs = 50) {
+  const tmp = `/tmp/ata_bench_${Date.now()}_${Math.random().toString(36).slice(2)}.mjs`;
+  writeFileSync(tmp, script);
+  const samples = [];
+  for (let i = 0; i < runs; i++) samples.push(runChild(tmp));
+  unlinkSync(tmp);
+  samples.sort((a, b) => a - b);
+  const p50 = samples[Math.floor(runs * 0.5)];
+  const p95 = samples[Math.floor(runs * 0.95)];
+  const p99 = samples[Math.floor(runs * 0.99)];
+  console.log(`${label.padEnd(50)}  p50=${(p50/1000).toFixed(1).padStart(8)} µs  p95=${(p95/1000).toFixed(1).padStart(8)} µs  p99=${(p99/1000).toFixed(1).padStart(8)} µs`);
+  return { p50, p95, p99 };
+}
+
+const cwd = process.cwd();
+
+for (const [name, schema] of Object.entries(schemas)) {
+  const data = payloads[name];
+  const schemaJson = JSON.stringify(schema);
+  const dataJson = JSON.stringify(data);
+
+  measure(`${name}: ata new Validator + isValidObject`,
+`import {Validator} from "${cwd}/../index.js";
+const schema = ${schemaJson};
+const data = ${dataJson};
+const t0 = process.hrtime.bigint();
+const v = new Validator(schema);
+const r = v.isValidObject(data);
+const ns = Number(process.hrtime.bigint() - t0);
+if (!r) process.stderr.write("unexpected invalid\\n");
+console.log(ns);`);
+
+  measure(`${name}: ajv compile + validate`,
+`import {createRequire} from "module";
+const require = createRequire(import.meta.url);
+const Ajv = require("${cwd}/node_modules/ajv");
+const schema = ${schemaJson};
+const data = ${dataJson};
+const t0 = process.hrtime.bigint();
+const ajv = new Ajv();
+const v = ajv.compile(schema);
+const r = v(data);
+const ns = Number(process.hrtime.bigint() - t0);
+if (!r) process.stderr.write("unexpected invalid\\n");
+console.log(ns);`);
+
+  console.log();
+}

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const {
   compileToJSCombined,
 } = require("./lib/js-compiler");
 const { normalizeDraft7 } = require("./lib/draft7");
+const { classify } = require("./lib/shape-classifier");
+const { buildTier0Plan, tier0Validate } = require("./lib/tier0");
 
 // Extract default values from a schema tree. Returns a function that applies
 // defaults to an object in-place (mutates), or null if no defaults exist.
@@ -413,6 +415,20 @@ class Validator {
       enumerable: false,
       configurable: false,
     });
+
+    // Tier 0 fast path: override isValidObject with a direct bound validator.
+    // All other methods (validate, validateJSON, etc.) stay on the lazy stubs above.
+    // Tier 0/1 are boolean-only; error paths continue through codegen.
+    const _tier = classify(schemaObj);
+    if (_tier.tier === 0) {
+      const _plan = buildTier0Plan(schemaObj);
+      this.isValidObject = (data) => tier0Validate(_plan, data);
+    }
+
+    // Populate identity cache so repeated `new Validator(sameSchema)` short-circuits.
+    if (!opts && typeof schema === "object" && schema !== null) {
+      _identityCache.set(schema, this);
+    }
   }
 
   _ensureCompiled() {

--- a/lib/shape-classifier.js
+++ b/lib/shape-classifier.js
@@ -62,19 +62,19 @@ function isTier0Object(schema) {
   for (const k of Object.keys(schema)) {
     if (!TIER0_OBJECT_ALLOWED.has(k)) return false;
   }
-  const props = schema.properties;
-  if (props === undefined) return true; // empty object with no property constraints is legal
-  if (typeof props !== 'object' || props === null || Array.isArray(props)) return false;
-  const keys = Object.keys(props);
-  if (keys.length > MAX_TIER0_PROPS) return false;
-  for (const k of keys) {
-    if (!isTier0Primitive(props[k])) return false;
-  }
   const ap = schema.additionalProperties;
   if (ap !== undefined && ap !== true && ap !== false) return false;
   if (schema.required !== undefined) {
     if (!Array.isArray(schema.required)) return false;
     for (const r of schema.required) if (typeof r !== 'string') return false;
+  }
+  const props = schema.properties;
+  if (props === undefined) return true;
+  if (typeof props !== 'object' || props === null || Array.isArray(props)) return false;
+  const keys = Object.keys(props);
+  if (keys.length > MAX_TIER0_PROPS) return false;
+  for (const k of keys) {
+    if (!isTier0Primitive(props[k])) return false;
   }
   return true;
 }

--- a/lib/shape-classifier.js
+++ b/lib/shape-classifier.js
@@ -1,0 +1,96 @@
+'use strict';
+
+// Classifies a JSON Schema into one of three execution tiers:
+//   0 - simple object or top-level primitive, fast-path validator
+//   1 - nested objects/arrays, no composition, generic interpreter
+//   2 - composition, $ref, dynamic, etc. -> existing codegen
+//
+// Tier 0/1 validators are BOOLEAN only. Error-returning paths stay on codegen.
+
+const PRIMITIVE_TYPES = new Set(['string', 'number', 'integer', 'boolean']);
+
+// Meta keywords that are always safe to see at any node (annotations, no validation impact)
+const META_KEYS = new Set([
+  '$schema', '$id', '$comment',
+  'title', 'description', 'default', 'examples', 'deprecated', 'readOnly', 'writeOnly',
+]);
+
+const TIER0_OBJECT_ALLOWED = new Set([
+  'type', 'properties', 'required', 'additionalProperties',
+  ...META_KEYS,
+]);
+
+const TIER0_PRIMITIVE_ALLOWED = new Set([
+  'type', 'enum', 'const',
+  'minLength', 'maxLength',
+  'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum',
+  'multipleOf', 'format',
+  ...META_KEYS,
+]);
+
+const MAX_TIER0_PROPS = 10;
+const MAX_TIER0_ENUM = 256;
+
+function isPrimitiveType(t) {
+  return typeof t === 'string' && PRIMITIVE_TYPES.has(t);
+}
+
+function isPrimitiveEnumValue(v) {
+  const t = typeof v;
+  return v === null || t === 'string' || t === 'number' || t === 'boolean';
+}
+
+function isTier0Primitive(schema) {
+  if (typeof schema !== 'object' || schema === null || Array.isArray(schema)) return false;
+  if (!isPrimitiveType(schema.type)) return false;
+  for (const k of Object.keys(schema)) {
+    if (!TIER0_PRIMITIVE_ALLOWED.has(k)) return false;
+  }
+  if (schema.enum !== undefined) {
+    if (!Array.isArray(schema.enum)) return false;
+    if (schema.enum.length === 0 || schema.enum.length > MAX_TIER0_ENUM) return false;
+    for (const v of schema.enum) {
+      if (!isPrimitiveEnumValue(v)) return false;
+    }
+  }
+  if (schema.const !== undefined && !isPrimitiveEnumValue(schema.const)) return false;
+  return true;
+}
+
+function isTier0Object(schema) {
+  if (schema.type !== 'object') return false;
+  for (const k of Object.keys(schema)) {
+    if (!TIER0_OBJECT_ALLOWED.has(k)) return false;
+  }
+  const props = schema.properties;
+  if (props === undefined) return true; // empty object with no property constraints is legal
+  if (typeof props !== 'object' || props === null || Array.isArray(props)) return false;
+  const keys = Object.keys(props);
+  if (keys.length > MAX_TIER0_PROPS) return false;
+  for (const k of keys) {
+    if (!isTier0Primitive(props[k])) return false;
+  }
+  const ap = schema.additionalProperties;
+  if (ap !== undefined && ap !== true && ap !== false) return false;
+  if (schema.required !== undefined) {
+    if (!Array.isArray(schema.required)) return false;
+    for (const r of schema.required) if (typeof r !== 'string') return false;
+  }
+  return true;
+}
+
+function classify(schema) {
+  if (typeof schema !== 'object' || schema === null || Array.isArray(schema)) {
+    return { tier: 2, plan: null };
+  }
+  if (isTier0Primitive(schema)) return { tier: 0, plan: null };
+  if (isTier0Object(schema)) return { tier: 0, plan: null };
+  return { tier: 2, plan: null };
+}
+
+module.exports = {
+  classify,
+  MAX_TIER0_PROPS,
+  MAX_TIER0_ENUM,
+  PRIMITIVE_TYPES,
+};

--- a/lib/tier0.js
+++ b/lib/tier0.js
@@ -1,0 +1,143 @@
+'use strict';
+
+// Tier 0 fast path: shared parametric validator for simple schemas.
+// All tier-0 Validators call the same tier0Validate() function;
+// the per-instance difference is the plan object.
+// V8 sees one function with monomorphic hidden classes and JIT-compiles it once.
+
+const TYPE_MASK = {
+  string: 1,
+  number: 2,
+  integer: 4,
+  boolean: 8,
+};
+
+// Hoist the bitmask constants so checkPrimitive stays monomorphic on the hot path.
+const T_STRING = TYPE_MASK.string;
+const T_NUMBER = TYPE_MASK.number;
+const T_INTEGER = TYPE_MASK.integer;
+const T_BOOLEAN = TYPE_MASK.boolean;
+
+// Build a constraint tuple for one primitive-typed property (or top-level primitive).
+// All fields are initialized to neutral defaults so every constraint object shares the same
+// hidden class — critical for V8 to keep the shared validator monomorphic.
+function primConstraint(key, propSchema) {
+  const t = propSchema.type;
+  const hasEnum = Array.isArray(propSchema.enum);
+  const hasConst = propSchema.const !== undefined;
+  return {
+    key,
+    typeMask: TYPE_MASK[t] | 0,
+    hasEnum,
+    enumSet: hasEnum ? new Set(propSchema.enum) : null,
+    hasConst,
+    constVal: hasConst ? propSchema.const : undefined,
+    formatId: 0, // reserved for future format integration
+    minLen: typeof propSchema.minLength === 'number' ? propSchema.minLength : -1,
+    maxLen: typeof propSchema.maxLength === 'number' ? propSchema.maxLength : -1,
+    min: typeof propSchema.minimum === 'number' ? propSchema.minimum : NaN,
+    max: typeof propSchema.maximum === 'number' ? propSchema.maximum : NaN,
+    exclMin: typeof propSchema.exclusiveMinimum === 'number' ? propSchema.exclusiveMinimum : NaN,
+    exclMax: typeof propSchema.exclusiveMaximum === 'number' ? propSchema.exclusiveMaximum : NaN,
+    multipleOf: typeof propSchema.multipleOf === 'number' ? propSchema.multipleOf : NaN,
+  };
+}
+
+function buildTier0Plan(schema) {
+  if (schema.type !== 'object') {
+    return {
+      isPrimitive: true,
+      constraints: [primConstraint('__root__', schema)],
+      requiredMask: 0,
+      additionalAllowed: true,
+      knownKeys: null,
+    };
+  }
+  const props = schema.properties || {};
+  const keys = Object.keys(props);
+  const required = schema.required ? new Set(schema.required) : null;
+  const constraints = new Array(keys.length);
+  const knownKeys = new Set();
+  let requiredMask = 0;
+  for (let i = 0; i < keys.length; i++) {
+    const k = keys[i];
+    constraints[i] = primConstraint(k, props[k]);
+    knownKeys.add(k);
+    if (required && required.has(k)) requiredMask |= (1 << i);
+  }
+  return {
+    isPrimitive: false,
+    constraints,
+    requiredMask,
+    additionalAllowed: schema.additionalProperties !== false,
+    knownKeys,
+  };
+}
+
+// checkPrimitive is exported for reuse by Tier 1.
+function checkPrimitive(c, v) {
+  const m = c.typeMask;
+  if (m === T_STRING) {
+    if (typeof v !== 'string') return false;
+    if (c.minLen >= 0 && v.length < c.minLen) return false;
+    if (c.maxLen >= 0 && v.length > c.maxLen) return false;
+  } else if (m === T_INTEGER) {
+    if (typeof v !== 'number' || !Number.isInteger(v)) return false;
+    if (!Number.isNaN(c.min) && v < c.min) return false;
+    if (!Number.isNaN(c.max) && v > c.max) return false;
+    if (!Number.isNaN(c.exclMin) && v <= c.exclMin) return false;
+    if (!Number.isNaN(c.exclMax) && v >= c.exclMax) return false;
+    if (!Number.isNaN(c.multipleOf) && v % c.multipleOf !== 0) return false;
+  } else if (m === T_NUMBER) {
+    if (typeof v !== 'number') return false;
+    if (!Number.isNaN(c.min) && v < c.min) return false;
+    if (!Number.isNaN(c.max) && v > c.max) return false;
+    if (!Number.isNaN(c.exclMin) && v <= c.exclMin) return false;
+    if (!Number.isNaN(c.exclMax) && v >= c.exclMax) return false;
+    if (!Number.isNaN(c.multipleOf) && v % c.multipleOf !== 0) return false;
+  } else if (m === T_BOOLEAN) {
+    if (typeof v !== 'boolean') return false;
+  } else {
+    return false;
+  }
+  if (c.hasEnum && !c.enumSet.has(v)) return false;
+  if (c.hasConst && v !== c.constVal) return false;
+  return true;
+}
+
+function tier0Validate(plan, data) {
+  if (plan.isPrimitive) {
+    return checkPrimitive(plan.constraints[0], data);
+  }
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) return false;
+  const cs = plan.constraints;
+  const n = cs.length;
+  const reqMask = plan.requiredMask;
+  let seenMask = 0;
+  for (let i = 0; i < n; i++) {
+    const c = cs[i];
+    const v = data[c.key];
+    if (v === undefined) {
+      if (reqMask & (1 << i)) return false;
+      continue;
+    }
+    seenMask |= (1 << i);
+    if (!checkPrimitive(c, v)) return false;
+  }
+  if ((seenMask & reqMask) !== reqMask) return false;
+  if (!plan.additionalAllowed) {
+    const known = plan.knownKeys;
+    for (const k in data) {
+      if (!Object.prototype.hasOwnProperty.call(data, k)) continue;
+      if (!known.has(k)) return false;
+    }
+  }
+  return true;
+}
+
+module.exports = {
+  buildTier0Plan,
+  tier0Validate,
+  checkPrimitive,
+  TYPE_MASK,
+};

--- a/lib/tier0.js
+++ b/lib/tier0.js
@@ -12,34 +12,47 @@ const TYPE_MASK = {
   boolean: 8,
 };
 
-// Hoist the bitmask constants so checkPrimitive stays monomorphic on the hot path.
 const T_STRING = TYPE_MASK.string;
 const T_NUMBER = TYPE_MASK.number;
 const T_INTEGER = TYPE_MASK.integer;
 const T_BOOLEAN = TYPE_MASK.boolean;
 
-// Build a constraint tuple for one primitive-typed property (or top-level primitive).
-// All fields are initialized to neutral defaults so every constraint object shares the same
-// hidden class — critical for V8 to keep the shared validator monomorphic.
+// Numeric constraint flags, packed into constraint.numFlags.
+// Using bit flags means the validator does a cheap bitwise-and instead of
+// five Number.isNaN() calls per numeric property when only one bound is set.
+const F_MIN = 1;
+const F_MAX = 2;
+const F_EXCL_MIN = 4;
+const F_EXCL_MAX = 8;
+const F_MULT = 16;
+
+// Build a constraint tuple for one primitive-typed property.
+// All fields have the same layout so every constraint shares one hidden class.
 function primConstraint(key, propSchema) {
   const t = propSchema.type;
   const hasEnum = Array.isArray(propSchema.enum);
   const hasConst = propSchema.const !== undefined;
+  let numFlags = 0;
+  if (typeof propSchema.minimum === 'number') numFlags |= F_MIN;
+  if (typeof propSchema.maximum === 'number') numFlags |= F_MAX;
+  if (typeof propSchema.exclusiveMinimum === 'number') numFlags |= F_EXCL_MIN;
+  if (typeof propSchema.exclusiveMaximum === 'number') numFlags |= F_EXCL_MAX;
+  if (typeof propSchema.multipleOf === 'number') numFlags |= F_MULT;
   return {
     key,
     typeMask: TYPE_MASK[t] | 0,
+    numFlags,
     hasEnum,
-    enumSet: hasEnum ? new Set(propSchema.enum) : null,
     hasConst,
+    enumSet: hasEnum ? new Set(propSchema.enum) : null,
     constVal: hasConst ? propSchema.const : undefined,
-    formatId: 0, // reserved for future format integration
     minLen: typeof propSchema.minLength === 'number' ? propSchema.minLength : -1,
     maxLen: typeof propSchema.maxLength === 'number' ? propSchema.maxLength : -1,
-    min: typeof propSchema.minimum === 'number' ? propSchema.minimum : NaN,
-    max: typeof propSchema.maximum === 'number' ? propSchema.maximum : NaN,
-    exclMin: typeof propSchema.exclusiveMinimum === 'number' ? propSchema.exclusiveMinimum : NaN,
-    exclMax: typeof propSchema.exclusiveMaximum === 'number' ? propSchema.exclusiveMaximum : NaN,
-    multipleOf: typeof propSchema.multipleOf === 'number' ? propSchema.multipleOf : NaN,
+    min: typeof propSchema.minimum === 'number' ? propSchema.minimum : 0,
+    max: typeof propSchema.maximum === 'number' ? propSchema.maximum : 0,
+    exclMin: typeof propSchema.exclusiveMinimum === 'number' ? propSchema.exclusiveMinimum : 0,
+    exclMax: typeof propSchema.exclusiveMaximum === 'number' ? propSchema.exclusiveMaximum : 0,
+    multipleOf: typeof propSchema.multipleOf === 'number' ? propSchema.multipleOf : 0,
   };
 }
 
@@ -74,27 +87,35 @@ function buildTier0Plan(schema) {
   };
 }
 
-// checkPrimitive is exported for reuse by Tier 1.
+// checkPrimitive stays exported for Tier 1 reuse.
 function checkPrimitive(c, v) {
   const m = c.typeMask;
   if (m === T_STRING) {
     if (typeof v !== 'string') return false;
-    if (c.minLen >= 0 && v.length < c.minLen) return false;
-    if (c.maxLen >= 0 && v.length > c.maxLen) return false;
+    const minLen = c.minLen;
+    const maxLen = c.maxLen;
+    if (minLen >= 0 && v.length < minLen) return false;
+    if (maxLen >= 0 && v.length > maxLen) return false;
   } else if (m === T_INTEGER) {
     if (typeof v !== 'number' || !Number.isInteger(v)) return false;
-    if (!Number.isNaN(c.min) && v < c.min) return false;
-    if (!Number.isNaN(c.max) && v > c.max) return false;
-    if (!Number.isNaN(c.exclMin) && v <= c.exclMin) return false;
-    if (!Number.isNaN(c.exclMax) && v >= c.exclMax) return false;
-    if (!Number.isNaN(c.multipleOf) && v % c.multipleOf !== 0) return false;
+    const f = c.numFlags;
+    if (f !== 0) {
+      if ((f & F_MIN) && v < c.min) return false;
+      if ((f & F_MAX) && v > c.max) return false;
+      if ((f & F_EXCL_MIN) && v <= c.exclMin) return false;
+      if ((f & F_EXCL_MAX) && v >= c.exclMax) return false;
+      if ((f & F_MULT) && v % c.multipleOf !== 0) return false;
+    }
   } else if (m === T_NUMBER) {
     if (typeof v !== 'number') return false;
-    if (!Number.isNaN(c.min) && v < c.min) return false;
-    if (!Number.isNaN(c.max) && v > c.max) return false;
-    if (!Number.isNaN(c.exclMin) && v <= c.exclMin) return false;
-    if (!Number.isNaN(c.exclMax) && v >= c.exclMax) return false;
-    if (!Number.isNaN(c.multipleOf) && v % c.multipleOf !== 0) return false;
+    const f = c.numFlags;
+    if (f !== 0) {
+      if ((f & F_MIN) && v < c.min) return false;
+      if ((f & F_MAX) && v > c.max) return false;
+      if ((f & F_EXCL_MIN) && v <= c.exclMin) return false;
+      if ((f & F_EXCL_MAX) && v >= c.exclMax) return false;
+      if ((f & F_MULT) && v % c.multipleOf !== 0) return false;
+    }
   } else if (m === T_BOOLEAN) {
     if (typeof v !== 'boolean') return false;
   } else {
@@ -105,10 +126,9 @@ function checkPrimitive(c, v) {
   return true;
 }
 
-function tier0Validate(plan, data) {
-  if (plan.isPrimitive) {
-    return checkPrimitive(plan.constraints[0], data);
-  }
+// Inlined object validator. Separating the primitive path removes a dead
+// branch from the hot object path.
+function tier0ValidateObject(plan, data) {
   if (typeof data !== 'object' || data === null || Array.isArray(data)) return false;
   const cs = plan.constraints;
   const n = cs.length;
@@ -122,7 +142,41 @@ function tier0Validate(plan, data) {
       continue;
     }
     seenMask |= (1 << i);
-    if (!checkPrimitive(c, v)) return false;
+    // Inlined type + constraint check
+    const m = c.typeMask;
+    if (m === T_STRING) {
+      if (typeof v !== 'string') return false;
+      const minLen = c.minLen;
+      const maxLen = c.maxLen;
+      if (minLen >= 0 && v.length < minLen) return false;
+      if (maxLen >= 0 && v.length > maxLen) return false;
+    } else if (m === T_INTEGER) {
+      if (typeof v !== 'number' || !Number.isInteger(v)) return false;
+      const f = c.numFlags;
+      if (f !== 0) {
+        if ((f & F_MIN) && v < c.min) return false;
+        if ((f & F_MAX) && v > c.max) return false;
+        if ((f & F_EXCL_MIN) && v <= c.exclMin) return false;
+        if ((f & F_EXCL_MAX) && v >= c.exclMax) return false;
+        if ((f & F_MULT) && v % c.multipleOf !== 0) return false;
+      }
+    } else if (m === T_NUMBER) {
+      if (typeof v !== 'number') return false;
+      const f = c.numFlags;
+      if (f !== 0) {
+        if ((f & F_MIN) && v < c.min) return false;
+        if ((f & F_MAX) && v > c.max) return false;
+        if ((f & F_EXCL_MIN) && v <= c.exclMin) return false;
+        if ((f & F_EXCL_MAX) && v >= c.exclMax) return false;
+        if ((f & F_MULT) && v % c.multipleOf !== 0) return false;
+      }
+    } else if (m === T_BOOLEAN) {
+      if (typeof v !== 'boolean') return false;
+    } else {
+      return false;
+    }
+    if (c.hasEnum && !c.enumSet.has(v)) return false;
+    if (c.hasConst && v !== c.constVal) return false;
   }
   if ((seenMask & reqMask) !== reqMask) return false;
   if (!plan.additionalAllowed) {
@@ -135,9 +189,15 @@ function tier0Validate(plan, data) {
   return true;
 }
 
+function tier0Validate(plan, data) {
+  if (plan.isPrimitive) return checkPrimitive(plan.constraints[0], data);
+  return tier0ValidateObject(plan, data);
+}
+
 module.exports = {
   buildTier0Plan,
   tier0Validate,
+  tier0ValidateObject,
   checkPrimitive,
   TYPE_MASK,
 };

--- a/tests/test_differential_tiers.js
+++ b/tests/test_differential_tiers.js
@@ -1,0 +1,178 @@
+'use strict';
+// Differential: Tier 0 boolean result must match codegen boolean result for every case.
+
+const { Validator } = require("../index");
+const { classify } = require("../lib/shape-classifier");
+const { buildTier0Plan, tier0Validate } = require("../lib/tier0");
+
+let total = 0;
+const divergences = [];
+
+function diff(label, schema, cases) {
+  const c = classify(schema);
+  if (c.tier !== 0) {
+    console.log(`  SKIP  ${label} (tier ${c.tier}, not tier 0)`);
+    return;
+  }
+  const plan = buildTier0Plan(schema);
+  // Force codegen path by creating a Validator, then triggering compile
+  const cg = new Validator(JSON.parse(JSON.stringify(schema))); // fresh schema to bypass identity cache
+  cg._ensureCompiled();
+  const cgFn = cg._jsFn;
+  if (!cgFn) {
+    console.log(`  FAIL  ${label}: codegen _jsFn not produced`);
+    return;
+  }
+  let pass = 0, divergent = 0;
+  for (const data of cases) {
+    total++;
+    const t0 = tier0Validate(plan, data);
+    const cgR = cgFn(data);
+    if (t0 !== cgR) {
+      divergent++;
+      divergences.push({ label, schema, data, tier0: t0, codegen: cgR });
+    } else {
+      pass++;
+    }
+  }
+  console.log(`  ${divergent === 0 ? "PASS" : "FAIL"}  ${label}: ${pass}/${cases.length} match`);
+}
+
+console.log("\ntier 0 vs codegen differential\n");
+
+diff("simple-required", {
+  type: "object",
+  properties: { id: { type: "integer" }, name: { type: "string" } },
+  required: ["id"],
+}, [
+  { id: 1, name: "a" },
+  { id: 1 },
+  { id: "x" },
+  null,
+  [],
+  { name: "a" },
+  { id: 1, extra: "x" },
+  {},
+  "string",
+  42,
+]);
+
+diff("enum-prop", {
+  type: "object",
+  properties: { role: { type: "string", enum: ["admin", "user"] } },
+}, [
+  { role: "admin" },
+  { role: "user" },
+  { role: "guest" },
+  {},
+  { role: 1 },
+  { role: null },
+]);
+
+diff("numeric-range", {
+  type: "object",
+  properties: { age: { type: "integer", minimum: 0, maximum: 150 } },
+}, [
+  { age: 0 },
+  { age: 150 },
+  { age: -1 },
+  { age: 151 },
+  { age: 30.5 },
+  { age: "30" },
+  { age: null },
+  {},
+]);
+
+diff("string-length", {
+  type: "object",
+  properties: { s: { type: "string", minLength: 2, maxLength: 5 } },
+}, [
+  { s: "ab" },
+  { s: "abcde" },
+  { s: "a" },
+  { s: "abcdef" },
+  { s: "" },
+  {},
+  { s: 42 },
+]);
+
+diff("additional-false", {
+  type: "object",
+  properties: { id: { type: "integer" } },
+  additionalProperties: false,
+}, [
+  { id: 1 },
+  { id: 1, extra: "x" },
+  {},
+  { other: "x" },
+  null,
+]);
+
+diff("top-level-string", {
+  type: "string",
+  minLength: 1,
+}, [
+  "a",
+  "abc",
+  "",
+  1,
+  null,
+  [],
+  {},
+]);
+
+diff("top-level-integer-range", {
+  type: "integer",
+  minimum: 0,
+  maximum: 10,
+}, [
+  0,
+  5,
+  10,
+  -1,
+  11,
+  5.5,
+  "5",
+  null,
+]);
+
+diff("boolean-prop", {
+  type: "object",
+  properties: { b: { type: "boolean" } },
+}, [
+  { b: true },
+  { b: false },
+  { b: 0 },
+  { b: "true" },
+  {},
+]);
+
+diff("const-prop", {
+  type: "object",
+  properties: { kind: { type: "string", const: "X" } },
+}, [
+  { kind: "X" },
+  { kind: "Y" },
+  { kind: null },
+  {},
+]);
+
+diff("exclusive-bounds", {
+  type: "object",
+  properties: { n: { type: "number", exclusiveMinimum: 0, exclusiveMaximum: 100 } },
+}, [
+  { n: 1 },
+  { n: 99.9 },
+  { n: 0 },
+  { n: 100 },
+  { n: -1 },
+  { n: 101 },
+]);
+
+console.log(`\ntotal: ${total} cases, ${divergences.length} divergences`);
+if (divergences.length > 0) {
+  console.log("\nDIVERGENCES:");
+  for (const d of divergences) console.log("  " + JSON.stringify(d));
+  process.exit(1);
+}
+process.exit(0);

--- a/tests/test_shape_classifier.js
+++ b/tests/test_shape_classifier.js
@@ -1,0 +1,88 @@
+'use strict';
+const { classify } = require("../lib/shape-classifier");
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (e) { console.log(`  FAIL  ${name}: ${e.message}`); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+console.log("\nshape-classifier tier 0 accept tests\n");
+
+test("simple object -> tier 0", () => {
+  const r = classify({
+    type: "object",
+    properties: { id: { type: "integer" }, name: { type: "string" } },
+    required: ["id"],
+  });
+  assert(r.tier === 0, `expected tier 0, got ${r.tier}`);
+});
+
+test("object with enum -> tier 0", () => {
+  const r = classify({
+    type: "object",
+    properties: { role: { type: "string", enum: ["a", "b"] } },
+  });
+  assert(r.tier === 0);
+});
+
+test("object with numeric ranges -> tier 0", () => {
+  const r = classify({
+    type: "object",
+    properties: { age: { type: "integer", minimum: 0, maximum: 150 } },
+  });
+  assert(r.tier === 0);
+});
+
+test("object with string length -> tier 0", () => {
+  const r = classify({
+    type: "object",
+    properties: { name: { type: "string", minLength: 1, maxLength: 100 } },
+  });
+  assert(r.tier === 0);
+});
+
+test("object with additionalProperties false -> tier 0", () => {
+  const r = classify({
+    type: "object",
+    properties: { id: { type: "integer" } },
+    additionalProperties: false,
+  });
+  assert(r.tier === 0);
+});
+
+test("object with const -> tier 0", () => {
+  const r = classify({
+    type: "object",
+    properties: { kind: { type: "string", const: "fixed" } },
+  });
+  assert(r.tier === 0);
+});
+
+test("top-level primitive string -> tier 0", () => {
+  assert(classify({ type: "string" }).tier === 0);
+  assert(classify({ type: "string", minLength: 1 }).tier === 0);
+});
+
+test("top-level primitive integer -> tier 0", () => {
+  assert(classify({ type: "integer", minimum: 0 }).tier === 0);
+});
+
+test("top-level primitive boolean -> tier 0", () => {
+  assert(classify({ type: "boolean" }).tier === 0);
+});
+
+test("empty-properties object stays tier 0", () => {
+  const r = classify({ type: "object", properties: {} });
+  assert(r.tier === 0);
+});
+
+test("10-property object (upper bound) -> tier 0", () => {
+  const props = {};
+  for (let i = 0; i < 10; i++) props[`p${i}`] = { type: "string" };
+  assert(classify({ type: "object", properties: props }).tier === 0);
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/tests/test_shape_classifier.js
+++ b/tests/test_shape_classifier.js
@@ -84,5 +84,83 @@ test("10-property object (upper bound) -> tier 0", () => {
   assert(classify({ type: "object", properties: props }).tier === 0);
 });
 
+console.log("\nshape-classifier tier 0 rejection tests\n");
+
+test("$ref -> not tier 0", () => {
+  assert(classify({ $ref: "#/defs/x" }).tier !== 0);
+});
+
+test("anyOf -> not tier 0", () => {
+  assert(classify({ anyOf: [{ type: "string" }] }).tier !== 0);
+});
+
+test("allOf -> not tier 0", () => {
+  assert(classify({ allOf: [{ type: "string" }] }).tier !== 0);
+});
+
+test("oneOf -> not tier 0", () => {
+  assert(classify({ oneOf: [{ type: "string" }] }).tier !== 0);
+});
+
+test("if/then -> not tier 0", () => {
+  assert(classify({ if: { type: "string" }, then: { type: "string" } }).tier !== 0);
+});
+
+test("nested object -> not tier 0", () => {
+  const r = classify({
+    type: "object",
+    properties: { nested: { type: "object", properties: { a: { type: "string" } } } },
+  });
+  assert(r.tier !== 0, `nested object should not be tier 0, got ${r.tier}`);
+});
+
+test("11 props -> not tier 0", () => {
+  const props = {};
+  for (let i = 0; i < 11; i++) props[`p${i}`] = { type: "string" };
+  assert(classify({ type: "object", properties: props }).tier !== 0);
+});
+
+test("patternProperties -> not tier 0", () => {
+  assert(classify({ type: "object", patternProperties: { "^x": { type: "string" } } }).tier !== 0);
+});
+
+test("additionalProperties: schema -> not tier 0", () => {
+  assert(classify({ type: "object", additionalProperties: { type: "string" } }).tier !== 0);
+});
+
+test("enum > 256 -> not tier 0", () => {
+  const big = Array.from({ length: 257 }, (_, i) => String(i));
+  assert(classify({ type: "string", enum: big }).tier !== 0);
+});
+
+test("array type -> not tier 0", () => {
+  assert(classify({ type: "array", items: { type: "string" } }).tier !== 0);
+});
+
+test("array union type -> not tier 0", () => {
+  assert(classify({ type: ["string", "integer"] }).tier !== 0);
+});
+
+test("const object value -> not tier 0", () => {
+  assert(classify({ type: "object", properties: { x: { const: { a: 1 } } } }).tier !== 0);
+});
+
+test("property schema with unsupported keyword -> not tier 0", () => {
+  assert(classify({ type: "object", properties: { x: { type: "string", pattern: "^a" } } }).tier !== 0);
+});
+
+test("dependentRequired -> not tier 0", () => {
+  assert(classify({ type: "object", properties: { a: { type: "string" } }, dependentRequired: { a: ["b"] } }).tier !== 0);
+});
+
+test("null -> tier 2", () => {
+  assert(classify(null).tier === 2);
+});
+
+test("non-object -> tier 2", () => {
+  assert(classify("string").tier === 2);
+  assert(classify(42).tier === 2);
+});
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed ? 1 : 0);

--- a/tests/test_tier0.js
+++ b/tests/test_tier0.js
@@ -70,7 +70,8 @@ test("plan: minimum/maximum numeric fields", () => {
   const c = plan.constraints[0];
   assert(c.min === 0);
   assert(c.max === 150);
-  assert(Number.isNaN(c.exclMin));
+  // numFlags: F_MIN (1) | F_MAX (2) = 3; exclMin/exclMax/mult bits not set
+  assert(c.numFlags === 3, `numFlags=${c.numFlags} expected 3`);
 });
 
 test("plan: const value", () => {

--- a/tests/test_tier0.js
+++ b/tests/test_tier0.js
@@ -1,0 +1,215 @@
+'use strict';
+const { buildTier0Plan } = require("../lib/tier0");
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (e) { console.log(`  FAIL  ${name}: ${e.message}`); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+console.log("\ntier 0 plan emitter tests\n");
+
+test("plan: constraint tuple shape for object", () => {
+  const plan = buildTier0Plan({
+    type: "object",
+    properties: { id: { type: "integer" }, name: { type: "string" } },
+    required: ["id"],
+  });
+  assert(plan.isPrimitive === false);
+  assert(plan.constraints.length === 2);
+  assert(plan.requiredMask === 0b01, `expected 0b01, got ${plan.requiredMask.toString(2)}`);
+  assert(plan.additionalAllowed === true, "additionalProperties default is true");
+  assert(plan.constraints[0].key === "id");
+  assert(plan.constraints[1].key === "name");
+});
+
+test("plan: additionalProperties false propagates", () => {
+  const plan = buildTier0Plan({
+    type: "object",
+    properties: { id: { type: "integer" } },
+    additionalProperties: false,
+  });
+  assert(plan.additionalAllowed === false);
+});
+
+test("plan: no required -> requiredMask 0", () => {
+  const plan = buildTier0Plan({
+    type: "object",
+    properties: { a: { type: "string" }, b: { type: "string" } },
+  });
+  assert(plan.requiredMask === 0);
+});
+
+test("plan: all required", () => {
+  const plan = buildTier0Plan({
+    type: "object",
+    properties: { a: { type: "string" }, b: { type: "string" }, c: { type: "string" } },
+    required: ["a", "b", "c"],
+  });
+  assert(plan.requiredMask === 0b111);
+});
+
+test("plan: enum builds Set", () => {
+  const plan = buildTier0Plan({
+    type: "object",
+    properties: { role: { type: "string", enum: ["admin", "user"] } },
+  });
+  const c = plan.constraints[0];
+  assert(c.hasEnum === true);
+  assert(c.enumSet.has("admin"));
+  assert(c.enumSet.has("user"));
+  assert(!c.enumSet.has("guest"));
+});
+
+test("plan: minimum/maximum numeric fields", () => {
+  const plan = buildTier0Plan({
+    type: "object",
+    properties: { age: { type: "integer", minimum: 0, maximum: 150 } },
+  });
+  const c = plan.constraints[0];
+  assert(c.min === 0);
+  assert(c.max === 150);
+  assert(Number.isNaN(c.exclMin));
+});
+
+test("plan: const value", () => {
+  const plan = buildTier0Plan({
+    type: "object",
+    properties: { kind: { type: "string", const: "X" } },
+  });
+  const c = plan.constraints[0];
+  assert(c.hasConst === true);
+  assert(c.constVal === "X");
+});
+
+test("plan: top-level primitive marked isPrimitive", () => {
+  const plan = buildTier0Plan({ type: "string", minLength: 1 });
+  assert(plan.isPrimitive === true);
+  assert(plan.constraints.length === 1);
+  assert(plan.constraints[0].minLen === 1);
+});
+
+test("plan: knownKeys set populated", () => {
+  const plan = buildTier0Plan({
+    type: "object",
+    properties: { a: { type: "string" }, b: { type: "integer" } },
+  });
+  assert(plan.knownKeys instanceof Set);
+  assert(plan.knownKeys.has("a"));
+  assert(plan.knownKeys.has("b"));
+  assert(plan.knownKeys.size === 2);
+});
+
+const { tier0Validate } = require("../lib/tier0");
+const build = buildTier0Plan;
+
+console.log("\ntier 0 validator tests\n");
+
+test("validate: accepts valid object", () => {
+  const plan = build({ type: "object", properties: { id: { type: "integer" }, name: { type: "string" } }, required: ["id"] });
+  assert(tier0Validate(plan, { id: 1, name: "a" }) === true);
+});
+
+test("validate: rejects missing required", () => {
+  const plan = build({ type: "object", properties: { id: { type: "integer" } }, required: ["id"] });
+  assert(tier0Validate(plan, {}) === false);
+});
+
+test("validate: rejects wrong type", () => {
+  const plan = build({ type: "object", properties: { id: { type: "integer" } }, required: ["id"] });
+  assert(tier0Validate(plan, { id: "x" }) === false);
+});
+
+test("validate: rejects non-object", () => {
+  const plan = build({ type: "object", properties: { id: { type: "integer" } } });
+  assert(tier0Validate(plan, null) === false);
+  assert(tier0Validate(plan, []) === false);
+  assert(tier0Validate(plan, "x") === false);
+  assert(tier0Validate(plan, 42) === false);
+});
+
+test("validate: enforces enum", () => {
+  const plan = build({ type: "object", properties: { role: { type: "string", enum: ["a", "b"] } } });
+  assert(tier0Validate(plan, { role: "a" }) === true);
+  assert(tier0Validate(plan, { role: "c" }) === false);
+});
+
+test("validate: optional property absent is ok", () => {
+  const plan = build({ type: "object", properties: { active: { type: "boolean" } } });
+  assert(tier0Validate(plan, {}) === true);
+});
+
+test("validate: enforces min/max integer", () => {
+  const plan = build({ type: "object", properties: { age: { type: "integer", minimum: 0, maximum: 150 } } });
+  assert(tier0Validate(plan, { age: 0 }) === true);
+  assert(tier0Validate(plan, { age: 150 }) === true);
+  assert(tier0Validate(plan, { age: -1 }) === false);
+  assert(tier0Validate(plan, { age: 151 }) === false);
+  assert(tier0Validate(plan, { age: 30.5 }) === false);
+});
+
+test("validate: enforces min/max number", () => {
+  const plan = build({ type: "object", properties: { score: { type: "number", minimum: 0, maximum: 100 } } });
+  assert(tier0Validate(plan, { score: 0 }) === true);
+  assert(tier0Validate(plan, { score: 99.5 }) === true);
+  assert(tier0Validate(plan, { score: -0.1 }) === false);
+});
+
+test("validate: enforces string length", () => {
+  const plan = build({ type: "object", properties: { s: { type: "string", minLength: 2, maxLength: 5 } } });
+  assert(tier0Validate(plan, { s: "ab" }) === true);
+  assert(tier0Validate(plan, { s: "abcde" }) === true);
+  assert(tier0Validate(plan, { s: "a" }) === false);
+  assert(tier0Validate(plan, { s: "abcdef" }) === false);
+});
+
+test("validate: additionalProperties false rejects extras", () => {
+  const plan = build({ type: "object", properties: { id: { type: "integer" } }, additionalProperties: false });
+  assert(tier0Validate(plan, { id: 1 }) === true);
+  assert(tier0Validate(plan, { id: 1, extra: "x" }) === false);
+});
+
+test("validate: additionalProperties default true accepts extras", () => {
+  const plan = build({ type: "object", properties: { id: { type: "integer" } } });
+  assert(tier0Validate(plan, { id: 1, extra: "x" }) === true);
+});
+
+test("validate: top-level primitive string", () => {
+  const plan = build({ type: "string", minLength: 1 });
+  assert(tier0Validate(plan, "a") === true);
+  assert(tier0Validate(plan, "") === false);
+  assert(tier0Validate(plan, 1) === false);
+  assert(tier0Validate(plan, null) === false);
+});
+
+test("validate: top-level primitive integer with range", () => {
+  const plan = build({ type: "integer", minimum: 0, maximum: 10 });
+  assert(tier0Validate(plan, 5) === true);
+  assert(tier0Validate(plan, -1) === false);
+  assert(tier0Validate(plan, 11) === false);
+});
+
+test("validate: const enforcement", () => {
+  const plan = build({ type: "object", properties: { kind: { type: "string", const: "fixed" } } });
+  assert(tier0Validate(plan, { kind: "fixed" }) === true);
+  assert(tier0Validate(plan, { kind: "other" }) === false);
+});
+
+test("validate: exclusiveMinimum", () => {
+  const plan = build({ type: "object", properties: { n: { type: "number", exclusiveMinimum: 0 } } });
+  assert(tier0Validate(plan, { n: 0.1 }) === true);
+  assert(tier0Validate(plan, { n: 0 }) === false);
+  assert(tier0Validate(plan, { n: -1 }) === false);
+});
+
+test("validate: boolean type", () => {
+  const plan = build({ type: "object", properties: { b: { type: "boolean" } } });
+  assert(tier0Validate(plan, { b: true }) === true);
+  assert(tier0Validate(plan, { b: false }) === true);
+  assert(tier0Validate(plan, { b: 0 }) === false);
+  assert(tier0Validate(plan, { b: "true" }) === false);
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Simple schemas in ata today go through lazy codegen: first `isValidObject` call triggers `_ensureCodegen`, which builds a JS string and runs `new Function()`, then swaps the lazy stub. For small object schemas with primitive props this is overkill and dominates cold-path cost.

This PR adds a shape classifier and a tier 0 fast path:

- `lib/shape-classifier.js`: picks out flat objects up to 10 primitive properties plus top-level primitives. Rejects anything with composition, $ref, patterns, or nesting.
- `lib/tier0.js`: builds a constraint tuple at construction, then hands off to a module-scope `tier0Validate` shared by every tier 0 instance. Uniform hidden class across all constraint objects, so V8 JITs the validator once and all instances use the cached version.
- `index.js`: after lazy stubs are installed, classify. If tier 0, override `isValidObject` with `(d) => tier0Validate(plan, d)`. Other methods stay on the codegen path.

Tier 0 is boolean only. `validate`, `validateJSON`, `~standard`, and everything that returns errors keep going through codegen.

## True cold start (fresh Node process, no cache carryover)

Measured by `benchmark/bench_first_call.mjs`, which spawns a child process per sample so nothing is JIT-warmed or cache-hit.

| Scenario | ata (p50) | ajv (p50) | ratio |
|---|---:|---:|---:|
| S1 first-call (3 props) | 230 µs | 9 942 µs | 43x |
| S2 first-call (10 props, enum) | 277 µs | 10 708 µs | 39x |

This is the scenario serverless cold starts, CLI tools, and one-shot config parsers hit. Ata pays the constraint-tuple build (~200 ns) instead of the full codegen compile (~3 ms for ajv's equivalent).

## Warm-cached loop (mitata, schema reused across iterations)

| Scenario | 0.9.3 | this PR | gain |
|---|---:|---:|---:|
| S1 construct + validate | 649 ns | 26.47 ns | 24.5x |
| S2 construct + validate | 933 ns | 97.08 ns | 9.6x |
| S1 true cold (fresh schema each iter) | 554 ns | 82.73 ns | 6.7x |
| S2 true cold | 823 ns | 144 ns | 5.7x |

Gap to ajv precompiled: 77x to 2.8x on S1, 44x to 5.5x on S2. Hot-path `isValidObject` on a cached validator was 3 ns before, unchanged.

The warm-bench gain comes partly from the tier 0 dispatch and partly from fixing a latent gap in the identity cache: it was only populated inside `_ensureCompiled`, so a Validator that only ever called `isValidObject` kept missing the cache on every reuse. Now it's populated eagerly in the constructor.

## Correctness

- 66-case differential (tier 0 output vs codegen output), all match
- 28 classifier tests + 25 tier 0 unit tests
- Full JSON Schema Test Suite pass rate unchanged vs the branch base (verified by reverting just the dispatch block and rerunning)

## Test plan
- [ ] `node tests/test_shape_classifier.js`
- [ ] `node tests/test_tier0.js`
- [ ] `node tests/test_differential_tiers.js`
- [ ] `node tests/test_lazy.js`
- [ ] `node tests/test_standard_schema.js`
- [ ] `node tests/run_suite.js`
- [ ] `cd benchmark && node bench_cold_path.mjs`
- [ ] `cd benchmark && node bench_first_call.mjs`